### PR TITLE
prevent tab groups from splitting when tabs aren't adjacent

### DIFF
--- a/src/GroupManager.ts
+++ b/src/GroupManager.ts
@@ -122,8 +122,66 @@ export class GroupManager {
     this.removePathFromAllGroups(path);
     const group = this.getGroup(groupId);
     if (!group) return;
+    
+    // Move the leaf right after the last tab in this group
+    this.moveLeafAfterLastGroupMember(leaf, group);
+    
     group.filePaths.push(path);
     await this.save();
+  }
+
+  // Helper to move a leaf right after all other tabs in the same group
+  private moveLeafAfterLastGroupMember(leaf: WorkspaceLeaf, group: TabGroup): void {
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const parent = leaf.parent as any;
+      if (!parent) return;
+
+      const children = parent.children || [];
+      
+      // Find the LAST position of any tab in this group
+      let lastGroupIndex = -1;
+      for (let i = 0; i < children.length; i++) {
+        const child = children[i];
+        if (child === leaf) continue; // Skip the tab we're moving
+        const childPath = leafFilePath(child);
+        if (childPath && group.filePaths.includes(childPath)) {
+          lastGroupIndex = i;
+        }
+      }
+      // Save state and detach
+      const viewState = leaf.getViewState();
+      const wasBeforeTarget = children.indexOf(leaf) < lastGroupIndex;
+      leaf.detach();
+      
+      // Adjust index if we were before the target (detaching shifts indices)
+      const targetIndex = wasBeforeTarget ? lastGroupIndex : lastGroupIndex + 1;
+      
+      // Create at the correct position
+      const newLeaf = this.plugin.app.workspace.createLeafInParent(parent, targetIndex);
+      newLeaf.setViewState(viewState);
+    } catch {
+      // Silently ignore errors
+    }
+  }
+
+  // Helper to move a leaf to the far right (end of all tabs)
+  private moveLeafToFarRight(leaf: WorkspaceLeaf): void {
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const parent = leaf.parent as any;
+      if (!parent) return;
+      
+      // Save the tab's state, detach it, then add it back at the end
+      const viewState = leaf.getViewState();
+      leaf.detach();
+      
+      // After detaching, just append to the end (no index needed)
+      const newLeaf = this.plugin.app.workspace.createLeafInParent(parent, 999);
+      newLeaf.setViewState(viewState);
+    } catch {
+      // Silently ignore errors
+    }
   }
 
   async removeLeafFromGroup(
@@ -134,6 +192,8 @@ export class GroupManager {
     if (!path) return;
     const group = this.getGroup(groupId);
     if (!group) return;
+    // Move the tab to the end so it doesn't split the group visually
+    this.moveLeafToFarRight(leaf); 
     group.filePaths = group.filePaths.filter((p) => p !== path);
     if (group.filePaths.length === 0) {
       await this.deleteGroup(groupId);


### PR DESCRIPTION
# Description
Previously, when adding a tab to an existing group, if the tab wasn't physically next to other group members, it would create separate visual groups with duplicate chips. The same issue occurred when removing a tab from the middle of a group.

# Changes:
- Add moveLeafAfterLastGroupMember() to position tabs after the last group member when adding to a group
- Add moveLeafToFarRight() to move removed tabs to the end, preventing group splits
- Use detach/reattach approach since Obsidian doesn't provide native tab reordering APIs
- Handle index adjustment when detaching affects target position
 
# References
Fixes #1
