### PR TITLE
fix: update group tabs after tab rename

### DIFF
--- a/src/GroupManager.ts
+++ b/src/GroupManager.ts
@@ -1,4 +1,4 @@
-import type { WorkspaceLeaf } from "obsidian";
+import type { TAbstractFile, WorkspaceLeaf } from "obsidian";
 import type { GroupColor, PluginData, PluginSettings, TabGroup } from "./types";
 import { DEFAULT_DATA } from "./types";
 import type TabGroupsPlugin from "./main";
@@ -174,5 +174,19 @@ export class GroupManager {
     }
     // Prune empty groups inline (without saving -> caller saves)
     this.data.groups = this.data.groups.filter((g) => g.filePaths.length > 0);
+  }
+
+  // Event handlers
+  async handleFileRename(
+    file: TAbstractFile,
+    oldPath: string,
+  ): Promise<void> {
+    const group = this.data.groups.find((g) => g.filePaths.includes(oldPath));
+    if (!group) return;
+
+    const newPath = file.path;
+    group.filePaths = group.filePaths.map((p) => p === oldPath ? newPath : p);
+
+    await this.save();
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -77,11 +77,11 @@ export default class TabGroupsPlugin extends Plugin {
     this.registerEvent(
       this.app.workspace.on("active-leaf-change", () => this.render()),
     );
-    this.app.vault.on("rename", (file, oldPath) => {
-      setTimeout(() => {
+    this.registerEvent(
+      this.app.vault.on("rename", (file, oldPath) => {
         this.groupManager.handleFileRename(file, oldPath);
-      }, 0);
-    });
+      }),
+    );
 
     // 6. Initial render
     // Wait one tick for Obsidian to finish restoring the layout

--- a/src/main.ts
+++ b/src/main.ts
@@ -77,6 +77,11 @@ export default class TabGroupsPlugin extends Plugin {
     this.registerEvent(
       this.app.workspace.on("active-leaf-change", () => this.render()),
     );
+    this.app.vault.on("rename", (file, oldPath) => {
+      setTimeout(() => {
+        this.groupManager.handleFileRename(file, oldPath);
+      }, 0);
+    });
 
     // 6. Initial render
     // Wait one tick for Obsidian to finish restoring the layout


### PR DESCRIPTION
# Description
- Renaming a tab inside a group caused it to be removed from its current group so I added an event handler for file renames to update the group with the new path.

> While working on this, I also noticed that `data.json` is never updated when a note inside a group is deleted so if you create a note, delete it, create a new note with the same title, it will appear in that group xd
I'll open another follow PR to address this issue.

# References
- fixes #2 

# Pull Request Checklist

- [x] Code builds without errors (`npm run build`)
- [x] Linter passes (`npm run lint`)
- [x] Manually tested in Obsidian (create, rename, recolor, collapse, delete, reload)
- [x] No unrelated changes included
- [x] Commit messages are clear and descriptive