### PR TITLE
fix(context-menu): append our context menu to Obsidian's

### DIFF
--- a/src/ContextMenu.ts
+++ b/src/ContextMenu.ts
@@ -118,7 +118,8 @@ class RenameGroupModal extends Modal {
 }
 
 // ContextMenuHandler
-// Registers a single delegated right-click listener on the workspace root.
+// Intercepts right-clicks on tab headers, builds a Menu, triggers Obsidian's
+// own "file-menu" event on it so Obsidian populates its default items, then appends our group items below a separator.
 
 export class ContextMenuHandler {
   private plugin: TabGroupsPlugin;
@@ -141,6 +142,9 @@ export class ContextMenuHandler {
     // Use contextmenu (right-click) on the whole document; we'll filter by
     // whether the target is inside a .workspace-tab-header
     document.addEventListener("contextmenu", this.boundHandler, true);
+    this.plugin.register(() =>
+      document.removeEventListener("contextmenu", this.boundHandler, true),
+    );
   }
 
   unregister(): void {
@@ -160,10 +164,23 @@ export class ContextMenuHandler {
     e.preventDefault();
     e.stopPropagation();
 
-    const existingGroup = this.manager.resolveGroupForLeaf(leaf);
     const menu = new Menu();
 
-    // "Add to group"
+    // Trigger Obsidian's own file-menu event
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const file = (leaf.view as any)?.file ?? null;
+    this.plugin.app.workspace.trigger(
+      "file-menu",
+      menu,
+      file,
+      "tab-header",
+      leaf,
+    );
+
+    // Append our group items below
+    menu.addSeparator();
+
+    const existingGroup = this.manager.resolveGroupForLeaf(leaf);
     const otherGroups = this.manager.groups.filter(
       (g) => g.id !== existingGroup?.id,
     );
@@ -211,8 +228,6 @@ export class ContextMenuHandler {
 
     // Existing group actions
     if (existingGroup) {
-      menu.addSeparator();
-
       menu.addItem((item) => {
         item
           .setTitle("Remove from group")

--- a/src/ContextMenu.ts
+++ b/src/ContextMenu.ts
@@ -1,5 +1,10 @@
 import { Menu, Modal, Setting, WorkspaceLeaf, type App } from "obsidian";
-import type { GroupColor } from "./types";
+import type {
+  GroupColor,
+  ObsidianFileView,
+  ObsidianLeaf,
+  ObsidianMenuItem,
+} from "./types";
 import { COLOR_VALUES, GROUP_COLORS } from "./types";
 import type { GroupManager } from "./GroupManager";
 import type TabGroupsPlugin from "./main";
@@ -167,8 +172,7 @@ export class ContextMenuHandler {
     const menu = new Menu();
 
     // Trigger Obsidian's own file-menu event
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const file = (leaf.view as any)?.file ?? null;
+    const file = (leaf.view as ObsidianFileView).file ?? null;
     this.plugin.app.workspace.trigger(
       "file-menu",
       menu,
@@ -189,9 +193,7 @@ export class ContextMenuHandler {
       menu.addItem((item) => {
         item.setTitle("Add to group").setIcon("folder-plus");
         // Build submenu
-        const submenu = (
-          item as unknown as { setSubmenu: () => Menu }
-        ).setSubmenu();
+        const submenu = (item as unknown as ObsidianMenuItem).setSubmenu();
 
         for (const g of otherGroups) {
           submenu.addItem((si) => {
@@ -201,7 +203,7 @@ export class ContextMenuHandler {
             });
             // Color dot via icon color hack
             const titleEl = (
-              si as unknown as { dom: HTMLElement }
+              si as unknown as ObsidianMenuItem
             ).dom?.querySelector(".menu-item-title");
             if (titleEl) {
               const dot = titleEl.createDiv({ cls: "menu-color-dot" });
@@ -256,9 +258,7 @@ export class ContextMenuHandler {
 
       menu.addItem((item) => {
         item.setTitle("Change group color").setIcon("palette");
-        const submenu = (
-          item as unknown as { setSubmenu: () => Menu }
-        ).setSubmenu();
+        const submenu = (item as unknown as ObsidianMenuItem).setSubmenu();
         for (const c of GROUP_COLORS) {
           submenu.addItem((si) => {
             si.setTitle(c.charAt(0).toUpperCase() + c.slice(1)).onClick(
@@ -306,8 +306,7 @@ export class ContextMenuHandler {
     let found: WorkspaceLeaf | null = null;
     this.plugin.app.workspace.iterateRootLeaves((leaf: WorkspaceLeaf) => {
       if (found) return;
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      if ((leaf as any).tabHeaderEl === tabHeader) {
+      if ((leaf as ObsidianLeaf).tabHeaderEl === tabHeader) {
         found = leaf;
       }
     });

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import type { Menu, TFile, WorkspaceLeaf, View } from "obsidian";
+
 export type GroupColor =
   | "grey"
   | "red"
@@ -58,3 +60,16 @@ export const DEFAULT_DATA: PluginData = {
   groups: [],
   settings: { ...DEFAULT_SETTINGS },
 };
+
+export interface ObsidianLeaf extends WorkspaceLeaf {
+  tabHeaderEl: HTMLElement;
+}
+
+export interface ObsidianFileView extends View {
+  file: TFile | null;
+}
+
+export interface ObsidianMenuItem {
+  setSubmenu: () => Menu;
+  dom: HTMLElement;
+}


### PR DESCRIPTION
# Description
Previously due to Obsidian very bad API for handling external event handlers, the easiest way to add an option to the default context menu was to override it :)

The workaround lasted long enough, this PR fixes this by finding a hack around the current API to append our own context menu items to the default ones.

# References

- fixes #5 
- similar reported issue Obsidian forms: https://forum.obsidian.md/t/allow-plugins-to-customize-all-context-menus/89861

# Pull Request Checklist

- [x] Code builds without errors (`npm run build`)
- [x] Linter passes (`npm run lint`)
- [x] Manually tested in Obsidian (create, rename, recolor, collapse, delete, reload)
- [x] No unrelated changes included
- [x] Commit messages are clear and descriptive