### PR TITLE
fix(settings): remove default color entry

### DIFF
--- a/src/SettingsTab.ts
+++ b/src/SettingsTab.ts
@@ -68,7 +68,6 @@ export class TabGroupsSettingTab extends PluginSettingTab {
     setting
       .setDesc(`${group.filePaths.length} file(s)`)
       .addDropdown((dd) => {
-        dd.addOption("", "Color…");
         for (const c of GROUP_COLORS) {
           dd.addOption(c, c.charAt(0).toUpperCase() + c.slice(1));
         }


### PR DESCRIPTION
# Description
You don't even need a default entry, every group is given one when created.

# References
- fixes #11 

# Pull Request Checklist

- [x] Code builds without errors (`npm run build`)
- [x] Linter passes (`npm run lint`)
- [x] Manually tested in Obsidian (create, rename, recolor, collapse, delete, reload)
- [x] No unrelated changes included
- [x] Commit messages are clear and descriptive